### PR TITLE
Add Slack API caching layer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools==2.1.0
 certifi==2018.1.18
 chardet==3.0.4
 flake8==3.5.0

--- a/slacker/commands/users/users_list_command.py
+++ b/slacker/commands/users/users_list_command.py
@@ -14,6 +14,9 @@ class UsersListCommand(Command):
   def is_destructive(self):
     return False
 
+  def use_cache(self):
+    return True
+
   def make_parser(self):
     parser = ArgumentParser(prog=self.name(), description=self.description())
     parser.add_argument("-l", "--limit", type=int, default=50,


### PR DESCRIPTION
Fixes #105.

Changes proposed in this pull request:
- Add option to include local cache for each command using `TTLCache` from the `cachetools` library.
- Added methods to base command with defaults that can be overridden in command subclass to configure command local caching.
- Enabled caching for `users.list`.
- Debug logging for cache hit/miss